### PR TITLE
Wire frasermolyneux-copilot MCP server (pinned v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,12 @@
 > - [`.github-copilot/.github/instructions/dotnet-nuget-library.instructions.md`](../../.github-copilot/.github/instructions/dotnet-nuget-library.instructions.md) — .NET NuGet library standards.
 > - [`.github-copilot/.github/instructions/dotnet-api-client-libraries.instructions.md`](../../.github-copilot/.github/instructions/dotnet-api-client-libraries.instructions.md) — typed API client patterns (three-package layout, fluent DI builder, `ApiResult<T>` envelope, authentication options, testing-package conventions).
 
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.
+
 ## Architecture
 - .NET 9 solution in `src/MX.GeoLocation.sln` with API (`MX.GeoLocation.Api.V1`) and MVC web (`MX.GeoLocation.Web`) projects plus abstractions, a generated API client, and a testing package.
 - Library packages: `MX.GeoLocation.Abstractions.V1`, `MX.GeoLocation.Api.Client.V1`, `MX.GeoLocation.Api.Client.Testing` (follow the standard three-package pattern).

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
 
       - name: Setup .NET
@@ -42,3 +43,12 @@ jobs:
             dotnet-version: |
               9.0.x
               10.0.x
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: npm ci && npm run build

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 ## Security
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+
+This repo wires the `frasermolyneux-copilot` MCP server so AI coding agents can query the shared `frasermolyneux/.github-copilot` catalog (instructions, prompts, agents) at runtime. The Copilot coding-agent config lives at [`.github/copilot/mcp_config.json`](.github/copilot/mcp_config.json) and the setup workflow at [`.github/workflows/copilot-setup-steps.yml`](.github/workflows/copilot-setup-steps.yml) checks out `.github-copilot` (pinned to tag `v0.1.0`) and builds the server before the agent runs. For tool surface, content-root resolution, and per-client wire-up snippets (VS Code, Claude Desktop, Copilot CLI), see [`.github-copilot/mcp-server/README.md`](https://github.com/frasermolyneux/.github-copilot/blob/v0.1.0/mcp-server/README.md).


### PR DESCRIPTION
Wires the `frasermolyneux-copilot` MCP server into this repo so AI coding agents (Copilot CLI, the Copilot coding agent, VS Code Chat, etc.) can query the shared `frasermolyneux/.github-copilot` catalog at runtime, rather than relying solely on file loads from a `.github-copilot/` checkout. Matches the pattern already merged into `portal-core`, pinned to tag `v0.1.0`.

## What changed

- `.github/workflows/copilot-setup-steps.yml` — pin the shared-copilot checkout to `refs/tags/v0.1.0`; add `actions/setup-node@v6` (Node 20.x) and a `Build MCP server` step (`npm ci && npm run build` in `.github-copilot/mcp-server`) after the existing `Setup .NET` step. The existing `Setup .NET` is preserved unchanged.
- `.github/copilot/mcp_config.json` (new) — declare the local stdio `frasermolyneux-copilot` server (`node .github-copilot/mcp-server/dist/index.js`) with `GH_COPILOT_CONTENT_ROOT=.github-copilot` for the Copilot coding agent.
- `.github/copilot-instructions.md` — insert the canonical `## Org conventions via MCP (when available)` section (byte-identical to the source-of-truth in `frasermolyneux/.github-copilot`, SHA-256 `DDAC8AA449794730F687EA61759C392D45C6C4E6C7A85C608EF365E15E748F6B`) between the top "Shared conventions" blockquote and `## Architecture`.
- `README.md` — append a brief `## Local dev: MCP wire-up` section pointing at the upstream `mcp-server/README.md` (no duplication).

## Notes for reviewers

- **`AGENTS.md` is intentionally not added here.** It does not yet exist in this repo and is owned by a separate metadata bootstrap pass. A follow-up MCP-wire iteration will insert the same canonical snippet there once `AGENTS.md` lands.
- **Behavioural change**: the `.github-copilot` checkout previously floated on the default branch and now pins to `v0.1.0`. Future tag bumps need a coordinated bump of the `ref:` value in `copilot-setup-steps.yml`.
- Validated locally: JSON and YAML parse cleanly; inserted snippet SHA-256 matches canonical exactly; `code-review` sub-agent returned no findings.