### PR TITLE
Fix Terraform dev bootstrap for Google Maps key

### DIFF
--- a/terraform/google_maps.tf
+++ b/terraform/google_maps.tf
@@ -1,8 +1,3 @@
-import {
-  to = google_apikeys_key.maps
-  id = "projects/${var.gcp_project_id}/locations/global/keys/maps-${var.environment}"
-}
-
 resource "google_apikeys_key" "maps" {
   name         = format("maps-%s", var.environment)
   display_name = format("Geo Location Maps API Key - %s", var.environment)


### PR DESCRIPTION
## Summary
Remove the unconditional Terraform `import` block for `google_apikeys_key.maps` so dev can bootstrap from empty state instead of failing when `maps-dev` does not already exist.

Closes #N/A

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Maintenance / refactor

## Validation evidence
```text
terraform -chdir=terraform fmt -check -recursive
(exit 0)
```

## Risk and rollout
Blast radius is low: only Terraform behavior for Google Maps API key import changes. This removes a hard plan-time dependency on an already-existing key and allows normal resource creation in clean dev environments. No manual post-merge steps required. Rollback is reverting this commit.

## Agent attestation
- [x] I followed repository and organization instructions referenced by AGENTS.md and .github/copilot-instructions.md.
- [x] I did not introduce secrets, connection strings, or hard-coded tenant/subscription identifiers.
- [x] I did not modify restricted automation/platform wiring outside task scope.
- [x] I kept the change scoped to the requested fix.

## Consumer impact
N/A