### PR TITLE
feat(client): adopt MX.Api.Client 2.3.77 shared cache configuration pattern

### DIFF
--- a/src/MX.GeoLocation.Abstractions.V1/MX.GeoLocation.Abstractions.V1.csproj
+++ b/src/MX.GeoLocation.Abstractions.V1/MX.GeoLocation.Abstractions.V1.csproj
@@ -40,7 +40,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+	  <PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
 	  <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	</ItemGroup>
 

--- a/src/MX.GeoLocation.Api.Client.Testing.Tests/MX.GeoLocation.Api.Client.Testing.Tests.csproj
+++ b/src/MX.GeoLocation.Api.Client.Testing.Tests/MX.GeoLocation.Api.Client.Testing.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/MX.GeoLocation.Api.Client.Testing/MX.GeoLocation.Api.Client.Testing.csproj
+++ b/src/MX.GeoLocation.Api.Client.Testing/MX.GeoLocation.Api.Client.Testing.csproj
@@ -15,8 +15,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+		<PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/MX.GeoLocation.Api.Client.Tests.V1/AddGeoLocationApiClientCompositionTests.cs
+++ b/src/MX.GeoLocation.Api.Client.Tests.V1/AddGeoLocationApiClientCompositionTests.cs
@@ -1,0 +1,112 @@
+using System;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Configuration;
+
+using MX.GeoLocation.Abstractions.Interfaces;
+using MX.GeoLocation.Abstractions.Interfaces.V1;
+using MX.GeoLocation.Abstractions.Models.V1;
+using MX.GeoLocation.Api.Client.V1;
+
+using V1_1 = MX.GeoLocation.Abstractions.Interfaces.V1_1;
+
+namespace MX.GeoLocation.Api.Client.Tests.V1;
+
+/// <summary>
+/// DI-composition regression tests for <see cref="ServiceCollectionExtensions.AddGeoLocationApiClient"/>.
+/// These lock in the shared-cache scoping fix — a consumer <c>WithCaching</c> delegate that targets
+/// multiple typed sub-APIs must not throw <see cref="ArgumentException"/> during registration when the
+/// same builder configuration is re-applied per typed client by MX.Api.Client.
+/// </summary>
+[Trait("Category", "Unit")]
+public class AddGeoLocationApiClientCompositionTests
+{
+    // Bogus interface used to force ValidateAllOperationsMatched() to detect a typo.
+    private interface INotRegisteredApi
+    {
+        System.Threading.Tasks.Task<ApiResult<GeoLocationDto>> Bogus(string hostname, System.Threading.CancellationToken ct = default);
+    }
+
+    [Fact]
+    public void AddGeoLocationApiClient_WithMultiSubApiCache_ResolvesEverySubApi()
+    {
+        // Arrange — a consumer delegate that captures cache expressions for BOTH the V1 and V1.1
+        // sub-APIs in a single .WithCaching(...). Before the SharedCacheConfiguration fix this
+        // would throw ArgumentException at BuildServiceProvider time because MX.Api.Client scoped
+        // WithCaching to whichever typed client was being registered at that moment.
+        var services = new ServiceCollection();
+
+        services.AddGeoLocationApiClient(options => options
+            .WithBaseUrl("https://example.invalid")
+            .WithApiKeyAuthentication("test-key")
+            .WithCachePartition("unit-tests")
+            .WithCaching(cache => cache
+                .UseLibraryDefaults()
+                .InMemory<IGeoLookupApi, System.Threading.Tasks.Task<ApiResult<GeoLocationDto>>>(
+                    api => api.GetGeoLocation(default!, default),
+                    TimeSpan.FromMinutes(30))
+                .InMemory<V1_1.IGeoLookupApi, System.Threading.Tasks.Task<ApiResult<MX.GeoLocation.Abstractions.Models.V1_1.CityGeoLocationDto>>>(
+                    api => api.GetCityGeoLocation(default!, default),
+                    TimeSpan.FromMinutes(30))));
+
+        using var provider = services.BuildServiceProvider(validateScopes: true);
+        using var scope = provider.CreateScope();
+        var sp = scope.ServiceProvider;
+
+        // Act + Assert — every registered sub-API and the unified client must resolve.
+        Assert.NotNull(sp.GetRequiredService<IGeoLookupApi>());
+        Assert.NotNull(sp.GetRequiredService<V1_1.IGeoLookupApi>());
+        Assert.NotNull(sp.GetRequiredService<IApiInfoApi>());
+        Assert.NotNull(sp.GetRequiredService<IApiHealthApi>());
+        Assert.NotNull(sp.GetRequiredService<IGeoLocationApiClient>());
+    }
+
+    [Fact]
+    public void AddGeoLocationApiClient_WithoutCaching_ResolvesEverySubApi()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        services.AddGeoLocationApiClient(options => options
+            .WithBaseUrl("https://example.invalid")
+            .WithApiKeyAuthentication("test-key"));
+
+        using var provider = services.BuildServiceProvider(validateScopes: true);
+        using var scope = provider.CreateScope();
+        var sp = scope.ServiceProvider;
+
+        // Act + Assert
+        Assert.NotNull(sp.GetRequiredService<IGeoLookupApi>());
+        Assert.NotNull(sp.GetRequiredService<V1_1.IGeoLookupApi>());
+        Assert.NotNull(sp.GetRequiredService<IApiInfoApi>());
+        Assert.NotNull(sp.GetRequiredService<IApiHealthApi>());
+        Assert.NotNull(sp.GetRequiredService<IGeoLocationApiClient>());
+    }
+
+    [Fact]
+    public void AddGeoLocationApiClient_WithCacheExpressionForUnknownInterface_ThrowsInvalidOperation()
+    {
+        // Arrange — a captured expression targets an interface that isn't a registered sub-API.
+        // SharedCacheConfiguration.ValidateAllOperationsMatched() must surface this as an
+        // InvalidOperationException so consumers catch typos at registration time.
+        var services = new ServiceCollection();
+
+        Action act = Register;
+
+        // Act + Assert
+        var ex = Assert.Throws<InvalidOperationException>(act);
+        Assert.Contains("shared cache operations", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        void Register()
+        {
+            services.AddGeoLocationApiClient(options => options
+                .WithBaseUrl("https://example.invalid")
+                .WithApiKeyAuthentication("test-key")
+                .WithCaching(cache => cache.InMemory<INotRegisteredApi, System.Threading.Tasks.Task<ApiResult<GeoLocationDto>>>(
+                    api => api.Bogus(default!, default),
+                    TimeSpan.FromMinutes(1))));
+        }
+    }
+}

--- a/src/MX.GeoLocation.Api.Client.Tests.V1/MX.GeoLocation.Api.Client.Tests.V1.csproj
+++ b/src/MX.GeoLocation.Api.Client.Tests.V1/MX.GeoLocation.Api.Client.Tests.V1.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/MX.GeoLocation.Api.Client.V1/Caching/GeoLocationApiCacheDefaults.cs
+++ b/src/MX.GeoLocation.Api.Client.V1/Caching/GeoLocationApiCacheDefaults.cs
@@ -1,0 +1,78 @@
+using System;
+
+using MX.Api.Abstractions;
+using MX.Api.Client.Configuration;
+
+using MX.GeoLocation.Abstractions.Interfaces.V1;
+using MX.GeoLocation.Abstractions.Models.V1;
+using MX.GeoLocation.Abstractions.Models.V1_1;
+
+using V1_1 = MX.GeoLocation.Abstractions.Interfaces.V1_1;
+
+namespace MX.GeoLocation.Api.Client.V1.Caching;
+
+/// <summary>
+/// Default library cache policies for the read-only GeoLocation lookup surface.
+/// Consumers opt in by calling <c>WithCaching(c =&gt; c.UseLibraryDefaults())</c> when
+/// registering <see cref="ServiceCollectionExtensions.AddGeoLocationApiClient"/>.
+/// </summary>
+/// <remarks>
+/// Only GET-style lookups are cached; write / delete / info / health operations are
+/// intentionally left uncached. TTLs favour freshness for volatile signals
+/// (ProxyCheck / IP intelligence) and stability for geographic mappings.
+/// </remarks>
+public static class GeoLocationApiCacheDefaults
+{
+    /// <summary>Default in-memory TTL for MaxMind v1.0 geolocation lookups.</summary>
+    public static readonly TimeSpan V1GeoLocationTtl = TimeSpan.FromMinutes(60);
+
+    /// <summary>Default in-memory TTL for MaxMind v1.1 city lookups.</summary>
+    public static readonly TimeSpan CityTtl = TimeSpan.FromMinutes(60);
+
+    /// <summary>Default in-memory TTL for MaxMind v1.1 insights lookups.</summary>
+    public static readonly TimeSpan InsightsTtl = TimeSpan.FromMinutes(30);
+
+    /// <summary>Default in-memory TTL for ProxyCheck.io risk lookups (short — risk signals change).</summary>
+    public static readonly TimeSpan ProxyCheckTtl = TimeSpan.FromMinutes(15);
+
+    /// <summary>Default in-memory TTL for merged IP intelligence lookups (bounded by ProxyCheck freshness).</summary>
+    public static readonly TimeSpan IntelligenceTtl = TimeSpan.FromMinutes(15);
+
+    /// <summary>
+    /// Configures cache defaults for <see cref="IGeoLookupApi"/> (v1.0). Only single-item GET is cached;
+    /// batch POST and DELETE are left uncached.
+    /// </summary>
+    public static void ConfigureV1(CacheBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.InMemory<IGeoLookupApi, System.Threading.Tasks.Task<ApiResult<GeoLocationDto>>>(
+            api => api.GetGeoLocation(default!, default),
+            V1GeoLocationTtl);
+    }
+
+    /// <summary>
+    /// Configures cache defaults for <see cref="V1_1.IGeoLookupApi"/> (v1.1). Only single-item GET lookups
+    /// are cached; batch intelligence POST and DELETE are left uncached.
+    /// </summary>
+    public static void ConfigureV1_1(CacheBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.InMemory<V1_1.IGeoLookupApi, System.Threading.Tasks.Task<ApiResult<CityGeoLocationDto>>>(
+            api => api.GetCityGeoLocation(default!, default),
+            CityTtl);
+
+        builder.InMemory<V1_1.IGeoLookupApi, System.Threading.Tasks.Task<ApiResult<InsightsGeoLocationDto>>>(
+            api => api.GetInsightsGeoLocation(default!, default),
+            InsightsTtl);
+
+        builder.InMemory<V1_1.IGeoLookupApi, System.Threading.Tasks.Task<ApiResult<ProxyCheckDto>>>(
+            api => api.GetProxyCheck(default!, default),
+            ProxyCheckTtl);
+
+        builder.InMemory<V1_1.IGeoLookupApi, System.Threading.Tasks.Task<ApiResult<IpIntelligenceDto>>>(
+            api => api.GetIpIntelligence(default!, default),
+            IntelligenceTtl);
+    }
+}

--- a/src/MX.GeoLocation.Api.Client.V1/GeoLocationApiOptionsBuilder.cs
+++ b/src/MX.GeoLocation.Api.Client.V1/GeoLocationApiOptionsBuilder.cs
@@ -1,3 +1,5 @@
+using System;
+
 using MX.Api.Client.Configuration;
 
 namespace MX.GeoLocation.Api.Client.V1;
@@ -11,4 +13,25 @@ public class GeoLocationApiOptionsBuilder : ApiClientOptionsBuilder<GeoLocationA
     /// Creates a new instance of the GeoLocationApiOptionsBuilder
     /// </summary>
     public GeoLocationApiOptionsBuilder() : base() { }
+
+    /// <summary>
+    /// Gets the cache configuration captured for later shared-scope application across the multiple
+    /// typed sub-API clients registered by <see cref="ServiceCollectionExtensions.AddGeoLocationApiClient"/>.
+    /// </summary>
+    internal Action<CacheBuilder>? CapturedCacheConfigure { get; private set; }
+
+    /// <summary>
+    /// Captures the caller's cache configuration without applying it to this builder's client scope.
+    /// The captured delegate is later re-applied per typed sub-API via
+    /// <see cref="ApiClientOptionsBuilder{TOptions, TBuilder}.WithSharedCaching(SharedCacheConfiguration)"/>,
+    /// which skips (rather than throws on) operations targeting sibling sub-APIs.
+    /// </summary>
+    /// <param name="configure">The cache policy configuration callback.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public new GeoLocationApiOptionsBuilder WithCaching(Action<CacheBuilder> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        CapturedCacheConfigure = configure;
+        return this;
+    }
 }

--- a/src/MX.GeoLocation.Api.Client.V1/MX.GeoLocation.Api.Client.V1.csproj
+++ b/src/MX.GeoLocation.Api.Client.V1/MX.GeoLocation.Api.Client.V1.csproj
@@ -17,17 +17,17 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Identity" Version="1.21.0" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
-		<PackageReference Include="MX.Api.Client" Version="2.3.67" />
-		<PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
+		<PackageReference Include="MX.Api.Client" Version="2.3.77" />
+		<PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="RestSharp" Version="114.0.0" />
 	</ItemGroup>

--- a/src/MX.GeoLocation.Api.Client.V1/ServiceCollectionExtensions.cs
+++ b/src/MX.GeoLocation.Api.Client.V1/ServiceCollectionExtensions.cs
@@ -1,9 +1,13 @@
+using System;
+
 using Microsoft.Extensions.DependencyInjection;
+
+using MX.Api.Client.Configuration;
+using MX.Api.Client.Extensions;
 
 using MX.GeoLocation.Abstractions.Interfaces;
 using MX.GeoLocation.Abstractions.Interfaces.V1;
-
-using MX.Api.Client.Extensions;
+using MX.GeoLocation.Api.Client.V1.Caching;
 
 namespace MX.GeoLocation.Api.Client.V1;
 
@@ -22,17 +26,42 @@ public static class ServiceCollectionExtensions
         this IServiceCollection serviceCollection,
         Action<GeoLocationApiOptionsBuilder> configureOptions)
     {
+        ArgumentNullException.ThrowIfNull(serviceCollection);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+
+        // Probe the caller-supplied delegate once against a throwaway builder to capture any
+        // cache configuration without binding it to a single typed sub-API scope. The overridden
+        // GeoLocationApiOptionsBuilder.WithCaching stashes the delegate on CapturedCacheConfigure
+        // instead of invoking it directly (which would fail scope validation when expressions
+        // target multiple sub-API interfaces).
+        var probe = new GeoLocationApiOptionsBuilder();
+        configureOptions(probe);
+        var capturedCache = probe.CapturedCacheConfigure;
+        var sharedCache = capturedCache is null ? null : new SharedCacheConfiguration(capturedCache);
+
+        var perClient = BuildPerClientConfigurator(configureOptions, sharedCache);
+
+        // Register library cache defaults for the read-only lookup surfaces BEFORE the typed
+        // clients so DefaultCachePolicies<TClient> singletons are visible during construction.
+        // Consumers opt in via WithCaching(c => c.UseLibraryDefaults()).
+        serviceCollection.AddDefaultCachePolicies<IGeoLookupApi>(GeoLocationApiCacheDefaults.ConfigureV1);
+        serviceCollection.AddDefaultCachePolicies<Abstractions.Interfaces.V1_1.IGeoLookupApi>(GeoLocationApiCacheDefaults.ConfigureV1_1);
+
         // Register V1 API using the new typed API client pattern
-        serviceCollection.AddTypedApiClient<IGeoLookupApi, GeoLookupApi, GeoLocationApiClientOptions, GeoLocationApiOptionsBuilder>(configureOptions);
+        serviceCollection.AddTypedApiClient<IGeoLookupApi, GeoLookupApi, GeoLocationApiClientOptions, GeoLocationApiOptionsBuilder>(perClient);
 
         // Register V1.1 API
-        serviceCollection.AddTypedApiClient<Abstractions.Interfaces.V1_1.IGeoLookupApi, GeoLookupApiV1_1, GeoLocationApiClientOptions, GeoLocationApiOptionsBuilder>(configureOptions);
+        serviceCollection.AddTypedApiClient<Abstractions.Interfaces.V1_1.IGeoLookupApi, GeoLookupApiV1_1, GeoLocationApiClientOptions, GeoLocationApiOptionsBuilder>(perClient);
 
         // Register API info endpoint
-        serviceCollection.AddTypedApiClient<IApiInfoApi, ApiInfoApi, GeoLocationApiClientOptions, GeoLocationApiOptionsBuilder>(configureOptions);
+        serviceCollection.AddTypedApiClient<IApiInfoApi, ApiInfoApi, GeoLocationApiClientOptions, GeoLocationApiOptionsBuilder>(perClient);
 
         // Register API health endpoint
-        serviceCollection.AddTypedApiClient<IApiHealthApi, ApiHealthApi, GeoLocationApiClientOptions, GeoLocationApiOptionsBuilder>(configureOptions);
+        serviceCollection.AddTypedApiClient<IApiHealthApi, ApiHealthApi, GeoLocationApiClientOptions, GeoLocationApiOptionsBuilder>(perClient);
+
+        // Fail fast at registration time if a captured cache expression targets an interface that
+        // is not assignable from any registered typed sub-API (typo guard).
+        sharedCache?.ValidateAllOperationsMatched();
 
         // Register version selectors as scoped
         serviceCollection.AddScoped<IVersionedGeoLookupApi, VersionedGeoLookupApi>();
@@ -43,5 +72,18 @@ public static class ServiceCollectionExtensions
         serviceCollection.AddScoped<IGeoLocationApiClient, GeoLocationApiClient>();
 
         return serviceCollection;
+    }
+
+    private static Action<GeoLocationApiOptionsBuilder> BuildPerClientConfigurator(
+        Action<GeoLocationApiOptionsBuilder> configureOptions,
+        SharedCacheConfiguration? sharedCache)
+    {
+        return sharedCache is null
+            ? configureOptions
+            : builder =>
+            {
+                configureOptions(builder);
+                builder.WithSharedCaching(sharedCache);
+            };
     }
 }

--- a/src/MX.GeoLocation.Api.V1/MX.GeoLocation.Api.V1.csproj
+++ b/src/MX.GeoLocation.Api.V1/MX.GeoLocation.Api.V1.csproj
@@ -16,10 +16,10 @@
 	<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
 	<PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="3.0.2" />
   <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.23.0" />
-	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-	<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
+	<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+	<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
 	<PackageReference Include="Microsoft.Identity.Web" Version="4.13.0" />
-	<PackageReference Include="MX.Api.Abstractions" Version="2.3.67" />
+	<PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
 	<PackageReference Include="MX.Api.Web.Extensions" Version="2.3.67" />
 	<PackageReference Include="MX.Observability.ApplicationInsights.AspNetCore" Version="1.1.24" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/src/MX.GeoLocation.Api.V1/MX.GeoLocation.Api.V1.csproj
+++ b/src/MX.GeoLocation.Api.V1/MX.GeoLocation.Api.V1.csproj
@@ -20,7 +20,7 @@
 	<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
 	<PackageReference Include="Microsoft.Identity.Web" Version="4.13.0" />
 	<PackageReference Include="MX.Api.Abstractions" Version="2.3.77" />
-	<PackageReference Include="MX.Api.Web.Extensions" Version="2.3.67" />
+	<PackageReference Include="MX.Api.Web.Extensions" Version="2.3.77" />
 	<PackageReference Include="MX.Observability.ApplicationInsights.AspNetCore" Version="1.1.24" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 	<PackageReference Include="Asp.Versioning.Mvc" Version="8.1.1" />

--- a/src/MX.GeoLocation.Web.IntegrationTests/MX.GeoLocation.Web.IntegrationTests.csproj
+++ b/src/MX.GeoLocation.Web.IntegrationTests/MX.GeoLocation.Web.IntegrationTests.csproj
@@ -27,9 +27,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Playwright" Version="1.61.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MX.GeoLocation.Web\MX.GeoLocation.Web.csproj" />

--- a/src/MX.GeoLocation.Web/MX.GeoLocation.Web.csproj
+++ b/src/MX.GeoLocation.Web/MX.GeoLocation.Web.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
-    <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.67" />
+    <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.77" />
     <PackageReference Include="MX.Observability.ApplicationInsights.AspNetCore" Version="1.1.24" />
   </ItemGroup>
 

--- a/src/MX.GeoLocation.Web/MX.GeoLocation.Web.csproj
+++ b/src/MX.GeoLocation.Web/MX.GeoLocation.Web.csproj
@@ -57,11 +57,11 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="3.0.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="MX.Api.Web.Extensions" Version="2.3.67" />
     <PackageReference Include="MX.Observability.ApplicationInsights.AspNetCore" Version="1.1.24" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Adopt MX.Api.Client 2.3.77's reflection-free `SharedCacheConfiguration` registration pattern in `MX.GeoLocation.Api.Client.V1`, add read-only library cache defaults for the GeoLookup surface, and lock the fix in with a DI-composition regression test. Consumers can now register cache expressions targeting multiple typed sub-APIs in a single `.WithCaching(...)` delegate without the previous `ArgumentException` scope crash at DI registration time.

Closes: agent task (no numbered issue)

## Type of change

- [x] bugfix
- [x] feature
- [ ] chore / refactor
- [ ] docs
- [ ] infra (Terraform)
- [ ] ci (GitHub Actions / Dependabot)
- [x] dependencies
- [ ] breaking change

## Required reading consulted

- [x] `AGENTS.md` (repo brief)
- [x] `.github/copilot-instructions.md` (repo orientation)
- [x] `.github-copilot/.github/instructions/personal.working-preferences.instructions.md` (always-on rules)
- [x] Stack-specific instruction files referenced in `AGENTS.md` (`standards.dotnet-project.instructions.md`, `standards.branching-and-prs.instructions.md`)

## Validation evidence

### Build

```text
$ dotnet build src/MX.GeoLocation.sln
...
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:11.61
```

### Tests

```text
$ dotnet test src/MX.GeoLocation.sln --filter "FullyQualifiedName!~IntegrationTests"
...
Passed!  - Failed:     0, Passed:     7, Skipped:     0, Total:     7, Duration: 218 ms - MX.GeoLocation.Api.Client.Tests.V1.dll (net9.0)
Passed!  - Failed:     0, Passed:   209, Skipped:     0, Total:   209, Duration: 156 ms - MX.GeoLocation.Api.Tests.V1.dll (net9.0)
Passed!  - Failed:     0, Passed:    42, Skipped:     0, Total:    42, Duration: 103 ms - MX.GeoLocation.Api.Client.Testing.Tests.dll (net9.0)
Passed!  - Failed:     0, Passed:    16, Skipped:     0, Total:    16, Duration: 203 ms - MX.GeoLocation.Web.Tests.dll (net9.0)
```

Total: 274 tests passed, 0 failed. The 3 new tests in `AddGeoLocationApiClientCompositionTests` are part of the `MX.GeoLocation.Api.Client.Tests.V1` count (previously 4, now 7).

### Format check

```text
$ dotnet format src/MX.GeoLocation.sln --verify-no-changes
(no output — pass)
```

## Risk and rollout

- **Blast radius:** `MX.GeoLocation.Api.Client.V1` NuGet package — consumed by the in-repo `MX.GeoLocation.Web` project and any external consumers of the client library. Also touches `MX.GeoLocation.Abstractions.V1`, `MX.GeoLocation.Api.V1`, and `MX.GeoLocation.Web` via transitive dependency version bumps (Microsoft.Extensions.* 10.0.9 → 10.0.10 patch, MX.Api.* 2.3.67 → 2.3.77).
- **Auto-deploys on merge?** Client NuGet package is published by CI on merge to `main`. The API + Web apps auto-deploy per the standard deploy-dev/deploy-prd workflows on `main`.
- **Manual steps post-merge:** None.
- **Rollback plan:** Revert the merge commit; NuGet consumers stay on the previous version until they choose to upgrade. Redeploy previous API/Web build via workflow re-run of the prior successful run.

## Consumer impact

- **Contracts touched:** `MX.GeoLocation.Api.Client.V1` — new public method `GeoLocationApiOptionsBuilder.WithCaching(Action<CacheBuilder>)` (method-hiding `new` override) and new public type `MX.GeoLocation.Api.Client.V1.Caching.GeoLocationApiCacheDefaults`. Registration semantics of `AddGeoLocationApiClient` now applies `WithSharedCaching` per typed sub-API and calls `SharedCacheConfiguration.ValidateAllOperationsMatched()` at the end.
- **Breaking?** No. Existing consumers with no `.WithCaching(...)` are unaffected. Existing single-scope `.WithCaching(...)` targeting `IGeoLookupApi` (V1) continues to work — the delegate is captured and re-applied per sub-API, and scope-mismatched siblings are silently skipped by `WithSharedCaching` instead of throwing. Any consumer that was previously relying on the crash to detect a typo will now get a clearer `InvalidOperationException` from `ValidateAllOperationsMatched()` at registration time instead.
- **Downstream consumers:** In-repo `MX.GeoLocation.Web` (no `.WithCaching` usage). Any external consumers of the client NuGet package.
- **Migration notes:** No code changes required. Consumers can now opt into library cache defaults with `.WithCaching(c => c.UseLibraryDefaults())` — defaults cover: v1 `GetGeoLocation` (60 min in-memory), v1.1 `GetCityGeoLocation` (60 min), `GetInsightsGeoLocation` (30 min), `GetProxyCheck` (15 min), `GetIpIntelligence` (15 min). Batch, delete, info, and health surfaces are intentionally uncached.

## Reviewer focus areas

- `src/MX.GeoLocation.Api.Client.V1/ServiceCollectionExtensions.cs` — capture-and-share flow: probe → `SharedCacheConfiguration` → per-client `WithSharedCaching` → `ValidateAllOperationsMatched`.
- `src/MX.GeoLocation.Api.Client.V1/GeoLocationApiOptionsBuilder.cs` — `new WithCaching` overload is intentional method-hiding; it stashes the delegate on `CapturedCacheConfigure` for the orchestrator to re-apply.
- `src/MX.GeoLocation.Api.Client.V1/Caching/GeoLocationApiCacheDefaults.cs` — TTL choices for read-only lookups. ProxyCheck / IP intelligence are deliberately shorter than MaxMind city/insights to bound risk-signal staleness.
- `src/MX.GeoLocation.Api.Client.Tests.V1/AddGeoLocationApiClientCompositionTests.cs` — the "multi-sub-API cache" test is the pre-fix crash reproducer; a passing run locks the regression down.

## Agent attestation

- [x] Ran `code-review` sub-agent; High/Medium findings resolved or justified above in **Reviewer focus areas** (review reported no significant issues)
- [x] PR body cites each acceptance criterion from the linked issue (task deliverable: 2.3.77 bump ✅, capture-and-share scoping ✅, read-only GeoLookup cache defaults ✅, DI-composition regression test under default filter ✅)
- [x] No client secrets, GUIDs, connection strings, or hard-coded subscription IDs introduced (`standards.oidc-and-secrets.instructions.md`)